### PR TITLE
Disabling replicaCount if autoscaling is enabled - prevents Flux from…

### DIFF
--- a/templates/autoscaler.yaml
+++ b/templates/autoscaler.yaml
@@ -13,8 +13,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "django-production-chart.releaseIdentifier" . }}
-  minReplicas: {{ .Values.minReplicas }}
-  maxReplicas: {{ .Values.maxReplicas }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
     - type: Resource
       resource:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -8,7 +8,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+{{ if .Values.autoscaling.enabled }}
+{{ else }}
   replicas: {{ .Values.replicaCount }}
+{{ end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "django-production-chart.releaseIdentifier" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -26,6 +26,12 @@ image:
 
 commitHash: eabc3212
 
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
… fighting with HPA

This is the "canonical" fix for https://github.com/uw-it-aca/gcp-flux-prod/pull/19