### PR TITLE
cronjob api version

### DIFF
--- a/templates/autoscaler.yaml
+++ b/templates/autoscaler.yaml
@@ -19,5 +19,7 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.targetAverageUtilization }}
+        target:
+          type: : Utilization
+          averageUtilization: {{ .Values.targetAverageUtilization }}
 {{- end }}

--- a/templates/autoscaler.yaml
+++ b/templates/autoscaler.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.deployment.enabled .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "django-production-chart.releaseIdentifier" . }}-autoscaler

--- a/templates/autoscaler.yaml
+++ b/templates/autoscaler.yaml
@@ -20,6 +20,6 @@ spec:
       resource:
         name: cpu
         target:
-          type: : Utilization
+          type: Utilization
           averageUtilization: {{ .Values.targetAverageUtilization }}
 {{- end }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -3,7 +3,7 @@
 {{- $namespace := include "django-production-chart.namespaceIdentifier" . -}}
 {{- range .Values.cronjob.jobs -}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ printf "%s-cronjob-%s" ( include "django-production-chart.releaseIdentifier" $dot ) .name }}


### PR DESCRIPTION
k8s 1.21 says:
Warning: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob