### PR TITLE
hook to override chart version

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -28,7 +28,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "django-production-chart.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Chart.Name ( .Values.chartVersion | default .Chart.Version ) | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{ define "django-production-chart.releaseIdentifier" -}}


### PR DESCRIPTION
doesn't appear Chart object values can be overridden