### PR TITLE
updated from v2beta2 to v2

### DIFF
--- a/templates/autoscaler.yaml
+++ b/templates/autoscaler.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.deployment.enabled .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "django-production-chart.releaseIdentifier" . }}-autoscaler


### PR DESCRIPTION
Squash Kubeval validation errors like:
```
VALIDATE generated manifest canvas-analytics.yaml
  ERR  - django-production-chart/templates/autoscaler.yaml: Failed initializing schema https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/horizontalpodautoscaler-autoscaling-v2beta2.json: Could not read schema from HTTP, response status is 404 Not Found
  Error: Process completed with exit code 1.
```